### PR TITLE
Implement Taiwanese Chinese localization

### DIFF
--- a/app/src/debug/res/values-zh-rTW/strings.xml
+++ b/app/src/debug/res/values-zh-rTW/strings.xml
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="app_name">TetherFi（開發版）</string>
+</resources>

--- a/connections/src/main/res/values-zh-rTW/strings.xml
+++ b/connections/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="connection_last_seen">上次發現時間：</string>
+    <string name="connection_options">連線選項</string>
+    <string
+        name="connection_total_to_internet"
+        >傳送至網際網路的資料總量：%1$s</string>
+    <string
+        name="connection_total_from_internet"
+        >接收自網際網路的資料總量：%1$s</string>
+    <string name="bandwidth_label">頻寬限制</string>
+    <string name="bandwidth_limit">%1$s：%2$s</string>
+    <string
+        name="connection_excuse"
+        >我們正在積極地研究一個更友善的解決方案。</string>
+    <string
+        name="connection_sorry"
+        >先跟您致上歉意。作業系統不讓我查看哪個 IP 地址是對應到哪些已連接設備，所以這個畫面只能夠讓您透過 IP 地址來進行管理。</string>
+    <string name="connection_none">當前還沒有任何連線！</string>
+    <string
+        name="connection_start_before_manage"
+        >啟動網路熱點以查看並管理已連接的裝置。</string>
+    <string
+        name="connection_running_explain"
+        >預設行為下任何連接的客戶端裝置皆允許透過網路熱點訪問網際網路。若您需要自網路阻擋特定的客戶端裝置您可以將您要限制的 IP 地址的開關關掉。</string>
+    <string name="option_set_nickname">設定暱稱</string>
+    <string name="option_set_bandwidth">設定頻寬限制</string>
+    <string name="bandwidth_over_limit">頻寬使用超限：%1$s</string>
+</resources>

--- a/info/src/main/res/values-zh-rTW/app_setup_strings.xml
+++ b/info/src/main/res/values-zh-rTW/app_setup_strings.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="turn_on_wi_fi">開啟 Wi-Fi。</string>
+  <string
+    name="wifi_must_be_on"
+  >您不需要連接至一個網路，但是 Wi-Fi 必須開啟以使 %1$s 正常運作。</string>
+  <string name="connect_internet">連接至網際網路</string>
+  <string
+    name="connect_internet_options"
+  >您可以連接至 Wi-Fi 或是行動網路</string>
+  <string
+    name="optionally_configure_hotspot"
+  >您可以設定網路名稱、密碼、代理服務的通訊埠號與無線廣播的頻段。</string>
+  <string
+    name="optionally_configure_wakelock"
+  >您另可以可選地選擇在網路熱點運作期間讓 CPU 及/或 Wi-Fi 保持清醒，此將大量提昇在螢幕關閉情境中的網路熱點性能。如果 CPU 未保持清醒狀態您可能會在裝置螢幕關閉時注意到極大的網路變慢。</string>
+  <string
+    name="optionally_configure_power"
+  >您另可以可選地選擇無視 Android 作業系統的電池最佳化設定，這樣會讓 %1$s 得以在所有時間以最大效能運行。這可能會使用更多的電池電量但是會顯著地改進您的網路體驗。</string>
+  <string name="start_the_hotspot">啟動 %1$s 的網路熱點。</string>
+  <string
+    name="check_hotspot_green"
+  >檢查廣播、代理、與網路熱點狀態皆顯示為正常且正在運行。</string>
+</resources>

--- a/info/src/main/res/values-zh-rTW/connection_complete_strings.xml
+++ b/info/src/main/res/values-zh-rTW/connection_complete_strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string
+    name="sharing_complete"
+  >您的裝置現在應已在分享它的網際網路連線！</string>
+  <string
+    name="sharing_caveat"
+  >到這地步，一般的上網跟收發電子郵件應該就能夠正常運作。如果沒有的話，自 %1$s 的網路熱點中斷連線並重新檢查您已經輸入了正確的網路與代理服務設定。</string>
+  <string
+    name="proxy_having_trouble"
+  >在設定代理服務設定時遇到問題嗎？於%1$s查看詳細設定指示。</string>
+  <string name="proxy_having_link_text">這邊</string>
+</resources>

--- a/info/src/main/res/values-zh-rTW/device_id_strings.xml
+++ b/info/src/main/res/values-zh-rTW/device_id_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="this_device">本裝置</string>
+  <string name="other_device">其他裝置</string>
+</resources>

--- a/info/src/main/res/values-zh-rTW/devivce_setup_strings.xml
+++ b/info/src/main/res/values-zh-rTW/devivce_setup_strings.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string
+    name="configure_the_proxy_settings"
+  >設定代理服務設定</string>
+  <string
+    name="http_manual_proxy"
+  >使用「手動」模式並設定 HTTP 跟 HTTPS 的代理服務設定。</string>
+  <string name="toggle_wifi">將 Wi-Fi 網路關閉並重新啟動。</string>
+  <string
+    name="automatically_connect"
+  >裝置應該會自動連接至 %1$s 網路熱點</string>
+  <string name="connect_to_hotspot">連接至 %1$s 網路熱點</string>
+  <string name="open_wifi_settings">打開 Wi-Fi 連線設定頁面</string>
+  <string name="label_hotspot_name">名稱</string>
+  <string name="label_hotspot_hostname">網址(URL)</string>
+  <string name="label_hotspot_port">通訊埠號</string>
+</resources>

--- a/settings/src/main/res/values-zh-rTW/debug_strings.xml
+++ b/settings/src/main/res/values-zh-rTW/debug_strings.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="yolo_title">強制發生 TCP 服務錯誤（用於測試頑固代理功能）</string>
+  <string
+      name="yolo_explain"
+      >強制模擬一個 TCP 服務的 IOException 例外錯誤，確認頑固代理(Subborn Proxy)功能是否正常運作（YOLO 模式）</string>
+  <string name="broadcast_title">強制發生廣播錯誤</string>
+  <string name="broadcast_explain">強制模擬發生了一個廣播錯誤(Broadcast Error)的情境</string>
+  <string name="proxy_title">強制發生代理錯誤</string>
+  <string name="proxy_explain">強制模擬發生了一個代理錯誤(Proxy Error)的情境</string>
+  <string name="empty_group_title">空群組資訊(Group Info)</string>
+  <string
+    name="empty_group_explain"
+  >強制 WiFi Direct 服務模擬傳回了一個空回應(empty response)的情境</string>
+  <string name="connected_group_title">已連接群組資訊(Connected Group Info)</string>
+  <string
+    name="connected_group_explain"
+  >強制 WiFi Direct 服務模擬傳回了一個已連接回應(connected response)的情境</string>
+  <string name="error_group_title">錯誤群組資訊(Error Group Info)</string>
+  <string
+    name="error_group_explain"
+  >強制 WiFi Direct 服務模擬傳回了一個錯誤回應(error response)的情境</string>
+  <string name="empty_connection_title">空連線資訊(Empty Connection Info)</string>
+  <string
+    name="empty_connection_explain"
+  >強制 WiFi Direct 服務模擬傳回了一個空連線回應(empty response)的情境</string>
+  <string name="connected_connection_title">已連接連線資訊(Connected Connection Info)</string>
+  <string
+    name="connected_connection_explain"
+  >強制 WiFi Direct 服務模擬傳回了一個已連接連線回應(connected response)的情境</string>
+  <string name="error_connection_title">錯誤連線資訊(Error Connection Info)</string>
+  <string
+    name="error_connection_explain"
+  >強制 WiFi Direct 服務模擬傳回了一個錯誤連線回應(error response)的情境</string>
+</resources>

--- a/settings/src/main/res/values-zh-rTW/settings_strings.xml
+++ b/settings/src/main/res/values-zh-rTW/settings_strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="settings">設定</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/blocker_strings.xml
+++ b/status/src/main/res/values-zh-rTW/blocker_strings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="block_privacy_policy">隱私政策</string>
+  <string name="block_view_privacy_policy">查看 %1$s 的%2$s</string>
+  <string name="block_vpn_title">與 VPN 發生衝突</string>
+  <string
+    name="block_vpn_description"
+  >%1$s 在連接 VPN 時可能會無法順利啟動網路熱點。</string>
+  <string
+    name="block_vpn_instruction"
+  >請將您的 VPN 中斷連線，然後再嘗試啟動熱點。</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/edit_mode_strings.xml
+++ b/status/src/main/res/values-zh-rTW/edit_mode_strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="editmode_hotspot_port">代理服務通訊埠號</string>
+  <string name="editmode_system_defined">由作業系統設定：無法變更</string>
+
+  <string name="editmode_type_port">通訊埠號</string>
+  <string name="editmode_type_ssid">網路名稱(SSID)</string>
+
+  <string name="editmode_label_map">%1$s是%2$s</string>
+  <string name="editmode_label_valid">有效的</string>
+  <string name="editmode_label_invalid">無效的</string>
+  <string name="editmode_label_visible">可見的</string>
+  <string name="editmode_label_hidden">隱藏的</string>
+  <string name="editmode_hotspot_password">熱點密碼</string>
+  <string name="editmode_hotspot_name">熱點名稱</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/network_bands_strings.xml
+++ b/status/src/main/res/values-zh-rTW/network_bands_strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="broadcast_frequency">廣播的無線通訊頻段</string>
+  <string
+    name="network_bands_system_defined"
+  >網路的廣播頻段由作業系統定義且無法被變更。</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/operating_settings_strings.xml
+++ b/status/src/main/res/values-zh-rTW/operating_settings_strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="operating_settings">熱點運作設定</string>
+  <string name="operating_always_alive_title">永遠存活</string>
+  <string
+    name="operating_always_alive_description"
+  >這會讓 %1$s 的網路熱點得以在應用軟體被關閉的情境繼續運行。這會大幅度改進您的使用體驗與網路效能。（建議使用）</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/perf_strings.xml
+++ b/status/src/main/res/values-zh-rTW/perf_strings.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="performance_title">性能相關設定</string>
+
+  <string name="perf_wake_lock_title">喚醒鎖</string>
+  <string
+    name="perf_wake_lock_description"
+  >喚醒鎖機制得以讓 %1$s 在螢幕關閉且系統處於低耗能模式下的維持高性能表現。在這些選項被啟用的狀況下您可能會注意到更高的電池電量消耗。</string>
+  <string name="perf_wifi_lock_title">保持 WiFi 喚醒</string>
+  <string
+    name="perf_wifi_lock_description"
+  >You should try this option first if Internet speed is slow on speed-tests while the screen is off.</string>
+  <string name="perf_cpu_lock_title">保持 CPU 喚醒</string>
+  <string
+    name="perf_cpu_lock_description"
+  >If WiFi is kept awake, and Internet speed is still slow on tests, you may need this option.</string>
+
+  <string name="perf_power_balance_title">專業設定：性能平衡設定</string>
+  <string
+    name="perf_power_balance_description"
+  >此設定僅提供給「進階使用者」使用。\n\n您可以透過調整分配給熱點網路的虛擬執行緒數量來調整 %1$s 網路熱點的效能表現跟資源使用量。\n\n更高的執行緒數量通常會促成更高的性能，但也會造成更高的電池電量使用且可能會使您的裝置更熱或更慢。</string>
+  <string name="perf_power_balance_button">調整性能</string>
+
+  <string name="perf_balance_max_title">最大性能</string>
+  <string
+    name="perf_balance_max_description"
+  >無執行緒數量限制。提供最大的性能表現。將電池電量使用顧慮丟出窗外。</string>
+  <string name="perf_balance_super_save_title">最大化節省電池電量使用</string>
+  <string
+    name="perf_balance_super_save_description"
+  >最多建立 %1$d 個執行緒。使用最少的電池電量但只提供最慢的網路熱點性能。</string>
+  <string name="perf_balance_save_title">省電模式</string>
+  <string
+    name="perf_balance_save_description"
+  >最多建立 %1$d 個執行緒。使用較少的電池電量但是提供較慢的網路熱點性能。</string>
+  <string name="perf_balance_normal_title">平衡</string>
+  <string
+    name="perf_balance_normal_description"
+  >最多建立 %1$d 個執行緒。提供電池電量使用與網路熱點性能間的平衡。</string>
+  <string name="perf_balance_perf_title">性能</string>
+  <string
+    name="perf_balance_perf_description"
+  >最多建立 %1$d 個執行緒。以更多電池電量使用為代價提供較佳的網路熱點性能。</string>
+  <string name="perf_balance_super_perf_title">高性能</string>
+  <string
+    name="perf_balance_super_perf_description"
+  >最多建立 %1$d 個執行緒。以更顯著的電池電量使用為代價提供非常好的網路熱點性能。</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/perf_strings.xml
+++ b/status/src/main/res/values-zh-rTW/perf_strings.xml
@@ -25,11 +25,11 @@
   <string name="perf_wifi_lock_title">保持 WiFi 喚醒</string>
   <string
     name="perf_wifi_lock_description"
-  >You should try this option first if Internet speed is slow on speed-tests while the screen is off.</string>
+  >如果網路速度測試在螢幕關閉時很慢的話您應該先試試看這個選項。</string>
   <string name="perf_cpu_lock_title">保持 CPU 喚醒</string>
   <string
     name="perf_cpu_lock_description"
-  >If WiFi is kept awake, and Internet speed is still slow on tests, you may need this option.</string>
+  >如果 WiFi 已經被保持於清醒狀態網路速度還是在網路速度測試中很慢的話，您可能需要使用這個選項。</string>
 
   <string name="perf_power_balance_title">專業設定：性能平衡設定</string>
   <string

--- a/status/src/main/res/values-zh-rTW/permission_strings.xml
+++ b/status/src/main/res/values-zh-rTW/permission_strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="permission_title">權限請求</string>
+  <string
+    name="permission_description"
+  >%1$s 需要 %2$s 權限以創建一個 Wi-Fi 群組</string>
+  <string
+    name="permission_reassure"
+  >%1$s 不會使用這些權限來進行除了 Wi-Fi 群組建立以外的任何事情。</string>
+  <string name="permission_open_settings">開啟設定</string>
+  <string name="permission_deny">拒絕</string>
+  <string name="permission_grant">授權</string>
+  <string name="permission_type_location">精確地理位置</string>
+  <string name="permission_type_nearby">鄰近 Wi-Fi 網路</string>
+
+  <string
+    name="permission_notification_title"
+  >顯示網路熱點通知</string>
+  <string
+    name="permission_notification_description"
+  >在新的 Android 版本中使網路熱點保持存活。\n\n在沒有通知的情境下，網路熱點可能會被系統隨機中止。</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/status_strings.xml
+++ b/status/src/main/res/values-zh-rTW/status_strings.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="status_error">發生了一個未預期的錯誤。</string>
+  <string name="status_not_running">未在運行</string>
+  <string name="status_running">正在運行</string>
+  <string name="status_starting">正在啟動</string>
+  <string name="status_stopping">正在中止</string>
+  <string name="enable_socket_timeout_title">啟用閒置連線逾時清理功能</string>
+  <string
+    name="enable_socket_timeout_description"
+  >在日常使用的情境下這個選項應該被啟用。這讓 %1$s 得以在超過一分鐘的無活動後清理老舊/已死亡的連線。在大量或長時間下載的情境中這個選項應該保持「禁用」。（建議使用）</string>
+
+  <string name="hotspot_error">%1$s 網路熱點錯誤</string>
+  <string name="start_hotspot">啟動 %1$s 網路熱點</string>
+  <string name="stop_hotspot">中止 %1$s 網路熱點</string>
+  <string name="is_thinking">%1$s 正在判斷當前狀態……</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/status_strings.xml
+++ b/status/src/main/res/values-zh-rTW/status_strings.xml
@@ -30,4 +30,8 @@
   <string name="start_hotspot">啟動 %1$s 網路熱點</string>
   <string name="stop_hotspot">中止 %1$s 網路熱點</string>
   <string name="is_thinking">%1$s 正在判斷當前狀態……</string>
+
+  <string name="title_broadcast_status">廣播狀態</string>
+  <string name="title_proxy_status">代理服務狀態</string>
+  <string name="title_hotspot_status">網路熱點狀態</string>
 </resources>

--- a/status/src/main/res/values-zh-rTW/tile_strings.xml
+++ b/status/src/main/res/values-zh-rTW/tile_strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="tile_qr_code">查看 QR 碼</string>
+  <string name="tile_hotspot_error">網路熱點錯誤</string>
+  <string name="tile_refresh_hotspot">重新設定網路熱點</string>
+  <string name="tile_network_error">網路錯誤</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/trouble_strings.xml
+++ b/status/src/main/res/values-zh-rTW/trouble_strings.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="trouble_title">%1$s 的網路熱點無法啟動。</string>
+  <string
+    name="trouble_description"
+  >這「不是」本應用軟體的錯誤，而是%1$s的錯誤。</string>
+
+  <string
+    name="trouble_err_type_both"
+  >您裝置與裝置設定</string>
+  <string name="trouble_err_type_proxy">您設定</string>
+  <string name="trouble_err_type_broadcast">您裝置</string>
+  <string
+    name="trouble_double_check"
+  >請檢查這些問題並再試一次：</string>
+  <string
+    name="trouble_broadcast_wifi_on"
+  >• Wi-Fi 功能必須被啟用以啟動網路熱點</string>
+  <string
+    name="trouble_broadcast_wifi_not_connected"
+  >• Wi-Fi 功能「不能」連接至任何其他網路</string>
+  <string
+    name="trouble_broadcast_wifi_restart"
+  >• Wi-Fi 功能必須透過將其停用再啟用的方式重新啟動</string>
+  <string
+    name="trouble_broadcast_password_length"
+  >• 網路熱點的密碼長度必須至少為 8 個字元</string>
+  <string
+    name="trouble_broadcast_ssid_name"
+  >• 網路熱點的名稱(SSID)必須是唯一的</string>
+  <string
+    name="trouble_proxy_already_used"
+  >• 網路熱點代理服務的通訊埠號可能已被另一個應用軟體使用</string>
+  <string
+    name="trouble_proxy_port"
+  >• 網路熱點代理服務的通訊埠號必須介於 1025 與 65000 之間</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/tweaks_strings.xml
+++ b/status/src/main/res/values-zh-rTW/tweaks_strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="tweaks_title">行為調整設定</string>
+  <string
+    name="tweaks_description"
+  >行為調整設定可在多個層面變更 %1$s 的運作方式。\n\n所有這些設定選項都是完全可選，且不會已任何方式對網路或網路熱點性能帶來任何負面影響。</string>
+
+  <string name="ignore_vpn_title">避免顯示 VPN 連線阻擋對話框</string>
+  <string
+    name="ignore_vpn_description"
+  >在網路熱點啟動時，%1$s 有時會在 VPN 連線存在情境中無法正常運作，故會在 VPN 連線未中止狀態下拒絕啟動網路熱點。\n\n如果您「已知」您的 VPN 應用可以與 %1$s 正常運作可以將這個選項啟用以避免出現阻擋對話框。</string>
+
+  <string name="shutdown_no_client_title">在沒有客戶端連線的情境下中止網路熱點服務</string>
+  <string
+    name="shutdown_no_client_description"
+  >如果 %1$s 網路熱點在沒有服務任何客戶端裝置情境下運行超過十分鐘就中止服務。\n\n在未使用情境下自動中止網路熱點服務可以節省電池電量消耗。</string>
+
+  <string name="stubborn_proxy_title">頑固代理服務模式</string>
+  <string
+    name="stubborn_proxy_description"
+  >在某些裝置上 %1$s 會在啟動代理服務時會發生「無效的引數(Invalid Argument)」錯誤無法啟動。在某些情況下，這個錯誤並不實際存在且可以透過頑固地不斷重試的方式恢復正常。\n\n啟用這個設定選項將使 %1$s 無視這些錯誤並不斷重試操作。即「你只能活一次何不試試(YOLO)」模式。\n\n這個設定選項現在已經是預設行為，並會在未來的應用軟體更新中被移除。</string>
+</resources>

--- a/status/src/main/res/values-zh-rTW/view_mode_strings.xml
+++ b/status/src/main/res/values-zh-rTW/view_mode_strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="viewmode_setup_instructions">設定步驟</string>
+  <string
+    name="viewmode_setup_view_instructions"
+  >不知道下一步要做什麼嗎？\n查看%1$s</string>
+  <string name="viewmode_hotspot_name">網路熱點名稱</string>
+  <string name="viewmode_hotspot_password">網路熱點密碼</string>
+  <string name="viewmode_hotspot_port">代理服務的通訊埠號</string>
+  <string name="viewmode_hotspot_hostname">代理服務的網址/主機名稱</string>
+</resources>

--- a/tile/src/main/res/values-zh-rTW/strings.xml
+++ b/tile/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+  <string
+      name="error_try_again"
+      >請打開 %1$s 應用軟體然後再重試一次。</string>
+    <string name="status_error">錯誤</string>
+    <string name="status_stopped">已停止</string>
+    <string name="status_running">正在運行</string>
+    <string name="status_starting">正在啟動……</string>
+    <string name="status_stopping">正在中止……</string>
+</resources>

--- a/ui/src/main/res/values-zh-rTW/hotspot_strings.xml
+++ b/ui/src/main/res/values-zh-rTW/hotspot_strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="ssid_no_name">**無名稱資訊**</string>
+  <string name="server_no_host">**無主機資訊**</string>
+  <string name="invalid_port">**無效的通訊埠號**</string>
+</resources>

--- a/ui/src/main/res/values-zh-rTW/password_strings.xml
+++ b/ui/src/main/res/values-zh-rTW/password_strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="password">密碼</string>
+  <string name="passwd_none">**無密碼資訊**</string>
+  <string name="pass_visible">密碼可見</string>
+  <string name="pass_hidden">密碼已被隱藏</string>
+</resources>

--- a/ui/src/main/res/values-zh-rTW/qr_strings.xml
+++ b/ui/src/main/res/values-zh-rTW/qr_strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="qr_code">QR 碼</string>
+  <string name="qr_code_explain">掃描這個 QR 碼以連接至網路</string>
+</resources>

--- a/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/ui/src/main/res/values-zh-rTW/strings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  ~ Copyright 2024 pyamsoft
+  ~ Copyright 2024 林博仁(Buo-ren, Lin)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at:
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="hotspot_error">Wi-Fi 網路熱點錯誤</string>
+  <string
+    name="faq_blurb"
+  >對 %1$s 如何運作存在疑問嗎？在連接網路期間有發現什麼問題嗎？查看我們的%2$s文章以及%3$s應用軟體清單</string>
+  <string name="faqs">常見問與答</string>
+  <string name="known_to_not_work">已知無法正常運作的</string>
+  <string name="view_information">查看資訊</string>
+  <string name="something_went_wrong">某個東西出錯了</string>
+  <string name="unknown_error">錯誤</string>
+</resources>


### PR DESCRIPTION
This patch provides user interface string translations in Taiwanese Chinese(as far as the current I18N implementation allows).

There are some UI strings that isn't translatable probably due to they're not marked as resource strings, or belong to another package(pydroid):

![Screenshot_20240629-162120](https://github.com/pyamsoft/tetherfi/assets/13408130/8c56789a-a5dd-4c22-8d7c-08b597e022d2)
![Screenshot_20240629-162156](https://github.com/pyamsoft/tetherfi/assets/13408130/5e68b390-effd-404b-9f8e-e43ddde8b91e)
